### PR TITLE
Being able to see AlSchemaValidator typings in vscode

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+import { AlSchemaValidator } from './src';

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "type": "git",
     "url": "https://github.com/alertlogic/nepal-haversack"
   },
+  "types": "./dist/typings/index.d.ts",
   "license": "MIT",
   "dependencies": {
     "ajv": "^6.10.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export { AlSchemaValidator } from './schema-validator';


### PR DESCRIPTION
Before

<img width="678" alt="Screen Shot 2019-07-17 at 9 10 30 AM" src="https://user-images.githubusercontent.com/15151450/61383115-ab4a7600-a873-11e9-827f-422b0b8e3204.png">


After

<img width="794" alt="Screen Shot 2019-07-17 at 9 06 17 AM" src="https://user-images.githubusercontent.com/15151450/61383136-b2718400-a873-11e9-9980-9ee319384415.png">
